### PR TITLE
feat(spec): Author LATER Protocol v1.0 Specification

### DIFF
--- a/specs/02-later-protocol/README.md
+++ b/specs/02-later-protocol/README.md
@@ -1,151 +1,254 @@
-# LATER Protocol Specification v1.0
+# LATER (Local Agent & Tool Execution Runtime) Protocol v1.0
 
 **Version:** 1.0.0
 **Status:** Final
+**Date:** August 2025
 
 ## 1. Introduction
 
-### 1.1. Vision
+### 1.1. Vision & Guiding Principles
 
-The LATER (Local Agent & Tool Execution Runtime) protocol provides a language-agnostic specification for discovering, registering, and executing tools **within a single application process**. It is designed to create a simple, intuitive, and "just works" developer experience for exposing local functions to AI agents.
+The **LATER (Local Agent & Tool Execution Runtime) Protocol** defines a language-agnostic standard for local, in-process AI tool execution. It is designed to provide a simple, introspection-first developer experience for integrating native code with AI agents, serving as the foundational layer for rapid prototyping and application-specific tooling.
 
-### 1.2. Guiding Principles
+LATER is governed by three core principles:
 
-*   **Simplicity:** The protocol prioritizes ease of implementation and use, minimizing boilerplate.
-*   **Introspection-First:** Compliant implementations should automatically generate tool schemas from native function signatures and documentation.
-*   **In-Process Focus:** LATER is exclusively concerned with local execution and makes no assertions about networking or distributed communication.
-*   **ALTAR Ecosystem Compatibility:** LATER is a foundational component of the ALTAR ecosystem, designed to provide a seamless promotion path for tools to the distributed GRID protocol.
+1.  **Implements the ADM:** LATER is a consumer of the **ALTAR Data Model (ADM)**. All data structures it produces and consumes (`FunctionDeclaration`, `FunctionCall`, `ToolResult`, etc.) must conform to the ADM v1.0 specification. This ensures seamless interoperability within the broader ALTAR ecosystem.
+2.  **Local-First, In-Process:** The protocol is strictly for tool execution within the same application process. The specification makes no provisions for networking, serialization for transport, or inter-process communication, as these concerns are explicitly delegated to the GRID protocol.
+3.  **Simplicity & Introspection:** The protocol prioritizes a simple developer experience. A compliant implementation must favor automated schema generation from native function signatures and documentation, minimizing boilerplate and manual configuration.
 
-### 1.3. Relationship to ALTAR Data Model
+### 1.2. Relationship to ADM & GRID
 
-The LATER protocol **imports and implements** the [**ALTAR Data Model (ADM) v1.0 specification**](../01-data-model/README.md). All data structures used for defining and interacting with tools (`FunctionDeclaration`, `Schema`, `FunctionCall`, `FunctionResponse`) MUST conform to the ADM standard. This shared contract is what guarantees a tool's portability from a local LATER runtime to a distributed GRID runtime.
+LATER is the second layer in the three-layer ALTAR architecture, positioned between the foundational data model and the distributed execution protocol.
+
+```mermaid
+graph TB
+    subgraph ALTAR Ecosystem
+        L3("
+            <strong>Layer 3: GRID Protocol</strong><br/><br/>
+            Distributed Tool Orchestration<br/>
+            Inter-Process & Network Communication<br/>
+            Manages Security & Transport
+        ")
+
+        L2("
+            <strong>Layer 2: LATER Protocol (This Specification)</strong><br/><br/>
+            Local Tool Execution Runtime<br/>
+            In-Process Function Calls<br/>
+            Automated Introspection
+        ")
+
+        L1("
+            <strong>Layer 1: ADM (ALTAR Data Model)</strong><br/><br/>
+            Universal Data Structures<br/>
+            Canonical Schemas & Contracts<br/>
+            (e.g., FunctionDeclaration, FunctionCall)
+        ")
+    end
+
+    %% --- Define Connections ---
+    L3 -- consumes --> L1
+    L2 -- implements --> L1
+
+    %% --- Styling ---
+    style L3 fill:#42a5f5,stroke:#1e88e5,color:#000000
+    style L2 fill:#1e88e5,stroke:#1565c0,color:#ffffff
+    style L1 fill:#0d47a1,stroke:#002171,color:#ffffff
+```
+
+*   **LATER implements the ADM:** It provides a standard for *creating* and *executing* tools that are described by ADM data structures.
+*   **LATER is the local companion to GRID:** Where GRID defines how tools operate across a network, LATER defines how they operate within a single process. This clear separation of concerns allows for a "promotion path" where a tool can graduate from a local LATER runtime to a distributed GRID runtime with no changes to its fundamental contract.
 
 ## 2. Abstract Protocol Definition
 
-A LATER-compliant implementation MUST provide the following abstract components and adhere to their specified behaviors.
+A LATER-compliant implementation must provide the following conceptual components and behaviors. These definitions are language-agnostic; the subsequent section provides a canonical implementation pattern in Elixir.
 
 ### 2.1. Tool Declaration Mechanism
 
-This is the primary developer interface for exposing a local function as a tool.
+A LATER implementation must provide an idiomatic, introspective mechanism for developers to declare native functions as AI tools.
 
 **Requirements:**
-1.  **Idiomatic Declaration:** An implementation MUST provide a mechanism for declaring a function as a tool that feels native to the host language (e.g., a macro in Elixir, a decorator in Python, an annotation in Java).
-2.  **Automated Introspection:** This mechanism MUST introspect the function's signature to automatically determine its name, parameters, and parameter types.
-3.  **Documentation Parsing:** It MUST parse standard function and parameter documentation (e.g., docstrings, `@doc` attributes) to populate the `description` fields in the generated schema.
-4.  **Global Registration:** Upon declaration (typically at compile- or load-time), the mechanism MUST register the generated tool definition with the Global Tool Definition Registry.
+
+1.  **Idiomatic Interface:** The mechanism must feel natural to the host programming language (e.g., decorators in Python, annotations in Java/C#, macros in Elixir).
+2.  **Automated Schema Generation:** The mechanism **must** introspect the native function's signature and documentation to automatically generate an ADM-compliant `FunctionDeclaration` schema. This includes:
+    *   **Name:** The function's name.
+    *   **Description:** The function's primary documentation string.
+    *   **Parameters:**
+        *   An ADM `Schema` object of type `OBJECT`.
+        *   `properties` derived from the function's parameter names and types. Native types must be mapped to their ADM `SchemaType` equivalents (e.g., `string` -> `STRING`, `int` -> `INTEGER`).
+        *   `description` for each parameter derived from its documentation.
+        *   `required` fields are inferred; parameters with default values are considered optional.
+3.  **Registration:** Upon declaration, the generated `FunctionDeclaration` and a reference to the executable function (e.g., a function pointer or lambda) must be registered with the **Global Tool Definition Registry**.
 
 ### 2.2. Two-Tier Registry Architecture
 
-LATER mandates a two-tiered registry to separate the application-wide *definition* of tools from their runtime *availability* within a specific context or session.
+LATER requires a two-tier registry system to manage the difference between a tool's definition and its availability within a specific operational context.
 
 #### 2.2.1. Global Tool Definition Registry
 
-A singleton, application-wide registry that holds the canonical definitions of all tools declared anywhere in the codebase.
-
-**Required Behaviors:**
-*   `register(tool_definition)`: Stores a `ToolDefinition` (containing the `FunctionDeclaration` schema and a language-specific function reference). It MUST handle name collisions by overwriting the existing entry and logging a warning.
-*   `lookup(tool_name)`: Retrieves a `ToolDefinition` by its unique name.
-*   `list()`: Returns a list of all globally registered `ToolDefinition`s.
+*   **Scope:** Application-wide, singleton.
+*   **Lifecycle:** Populated at application startup or compile-time as tools are declared. Persists for the life of the application.
+*   **Contents:**
+    1.  The complete, ADM-compliant `FunctionDeclaration` for every tool.
+    2.  An internal reference or handle to the actual executable function.
+*   **Responsibility:** Acts as the single source of truth for all tool schemas and their corresponding business logic.
 
 #### 2.2.2. Session-Scoped Registry
 
-An isolated, ephemeral registry that manages which tools are available within a specific runtime session.
-
-**Required Behaviors:**
-*   `create_session(session_id, enabled_tools)`: Creates a new session context. The `enabled_tools` argument is a list of tool names that will be made available. The session registry fetches these definitions from the Global Registry.
-*   `list_declarations(session_id)`: Returns a list of `FunctionDeclaration` schemas for all tools enabled in that session. This is the primary method used by a host application to inform an LLM of available tools.
-*   `lookup(session_id, tool_name)`: Retrieves the `ToolDefinition` for a given tool, but only if it is enabled for the specified session.
-*   `destroy_session(session_id)`: Cleans up all resources associated with the session.
+*   **Scope:** Ephemeral, tied to a specific "session" or "conversation."
+*   **Lifecycle:** Created when a session begins and destroyed when it ends.
+*   **Contents:** A list of tool names that are active for that session. It does not store schemas directly, but rather references the tools available in the Global Registry.
+*   **Responsibility:** Manages which tools are available for a given AI interaction. This allows a host application to selectively expose a subset of all globally-defined tools to the agent based on context, user permissions, or conversation state.
 
 ### 2.3. Local Tool Executor
 
-The component responsible for invoking a local function in response to a `FunctionCall`.
+The Executor is responsible for invoking a tool's business logic in response to an agent's request.
 
-**Required Behaviors:**
-*   `execute(session_id, function_call)`: The primary execution function.
-    1.  It MUST use the Session-Scoped Registry to verify that the tool in the `function_call` exists and is enabled for the given `session_id`.
-    2.  It MUST validate the `args` from the `FunctionCall` against the tool's `parameters` schema.
-    3.  It MUST safely invoke the underlying local function with the validated arguments.
-    4.  It MUST handle any exceptions during execution and format them into a structured `ErrorResponse`.
-    5.  It MUST return a `FunctionResponse` containing the JSON-serializable result on success.
-    6.  It MUST be implemented in a way that is safe for concurrent execution, according to the host language's concurrency model (e.g., process safety in Elixir, thread safety in Python/Java).
+**Requirements:**
+
+1.  **Lookup:** Given a `FunctionCall` from an agent, the Executor must first look up the corresponding tool in the relevant **Session-Scoped Registry** to confirm its availability.
+2.  **Validation:** It must then retrieve the tool's `FunctionDeclaration` from the **Global Registry** and validate the incoming `args` from the `FunctionCall` against the parameter schema. This includes checking for required parameters, validating data types, and respecting `enum` constraints.
+3.  **Invocation:** If validation succeeds, the Executor invokes the referenced native function, passing the `args` as arguments.
+4.  **Response Handling:**
+    *   On successful execution, it must wrap the function's return value in an ADM-compliant `ToolResult` with a `status` of `SUCCESS`.
+    *   On any failure (validation error, runtime exception, etc.), it must construct a `ToolResult` with a `status` of `ERROR` and a structured `ErrorObject` containing a clear message.
 
 ## 3. Canonical Implementation Pattern: Elixir
 
-This section describes how the abstract LATER protocol requirements can be idiomatically fulfilled in Elixir. This serves as a reference for other language implementations.
+This section provides a brief, non-normative example of how the abstract protocol can be idiomatically implemented in Elixir. This serves as a reference for implementers in other languages.
 
-### 3.1. Tool Declaration (`deftool` Macro)
+#### 3.1. Tool Declaration with `deftool`
 
-The **Tool Declaration Mechanism** is implemented via a `deftool/2` macro.
+A `deftool` macro leverages Elixir's metaprogramming to satisfy the **Tool Declaration Mechanism** requirement.
 
 ```elixir
-defmodule MyApp.WeatherTools do
-  # Provides the deftool macro
-  use LATER.Tools 
+# lib/my_app/calculator_tools.ex
+defmodule MyApp.CalculatorTools do
+  use Later.Tools # Imports the deftool macro
 
   @doc """
-  Gets the current weather for a given location.
+  Adds two numbers together.
   """
-  deftool get_current_weather(location, unit \\ "celsius") 
-  when is_binary(location) and unit in ["celsius", "fahrenheit"] do
-    # Function body that calls a weather service...
-    %{temperature: 22, unit: unit, forecast: "windy"}
+  deftool add(a, b) do
+    {:ok, a + b}
+  end
+
+  @doc """
+  Calculates the total price including tax.
+  @param unit_price The price of a single item.
+  @param quantity The number of items.
+  @param tax_rate The tax rate as a decimal (e.g., 0.08 for 8%).
+  """
+  deftool calculate_total(unit_price, quantity, tax_rate \\ 0.0) do
+    total = unit_price * quantity * (1 + tax_rate)
+    {:ok, total}
   end
 end
 ```
 
-*   **Introspection:** The macro inspects the Abstract Syntax Tree (AST) of the function definition at compile time.
-*   **Schema Generation:** It uses function head guards (`is_binary/1`) and typespecs (`@spec`) to map Elixir types to ADM `Schema` types.
-*   **Global Registration:** It calls `LATER.GlobalRegistry.register/1` with the generated `ToolDefinition`.
+*   **Introspection:** The `deftool` macro uses `Code.get_doc/2` at compile time to get the function and parameter documentation. It introspects the abstract syntax tree (AST) to find parameter names and default values.
+*   **Registration:** It generates an ADM `FunctionDeclaration` and registers it along with the function reference (`&add/2`) into an ETS-based **Global Tool Definition Registry**.
 
-### 3.2. Registries (GenServer & ETS)
+#### 3.2. Registries and Executor
 
-*   **Global Tool Definition Registry:** Implemented as a simple ETS table, populated at compile time by the `deftool` macro. This provides fast, concurrent, read-only access at runtime.
-*   **Session-Scoped Registry:** Implemented as a `GenServer` that manages an in-memory map of `%{session_id => enabled_tools}`. When a session is created, this GenServer fetches the required definitions from the global ETS table and stores references in its state.
-
-### 3.3. Executor (Module)
-
-The **Local Tool Executor** is implemented as a standard Elixir module.
+*   **Global Registry:** A simple `GenServer` or ETS table that stores `{function_name, arity}` as a key and the `FunctionDeclaration` and `MFA` `{module, function, args}` as the value.
+*   **Session Registry:** A `GenServer` per session, holding a `MapSet` of active tool names for that session.
+*   **Executor:** A module with an `execute/2` function that performs the lookup, validation, and invocation logic.
 
 ```elixir
-# Simplified example of the Executor's main function
-defmodule LATER.Executor do
+# Simplified Executor Logic
+defmodule Later.Executor do
   def execute(session_id, %FunctionCall{name: name, args: args}) do
-    with {:ok, tool_def} <- LATER.SessionRegistry.lookup(session_id, name),
-         :ok <- validate_parameters(tool_def.schema, args) do
-      # apply/3 invokes the {Module, :function, [args]} reference
-      result = apply(tool_def.function_reference, [args])
-      {:ok, %FunctionResponse{name: name, response: %{content: result}}}
-    rescue
-      e -> {:error, format_exception_as_error_response(name, e)}
+    with {:ok, mfa} <- Registry.lookup(session_id, name),
+         :ok <- Validator.validate(mfa, args) do
+      # Apply the function and wrap in a ToolResult
+      apply(mfa.module, mfa.function, Map.values(args))
+      |> wrap_in_tool_result(name)
+    else
+      {:error, reason} ->
+        # Return an error ToolResult
+        Later.Types.ToolResult.error(name, reason)
     end
   end
 end
 ```
 
-## 4. End-to-End Workflow Example (in `gemini_ex`)
+## 4. End-to-End Workflow Example
 
-This diagram and code illustrate how a host application like `gemini_ex` would use a LATER implementation.
+This example illustrates the complete LATER protocol flow from the perspective of a host application (e.g., `gemini_ex`).
 
 ```mermaid
 sequenceDiagram
-    participant App as gemini_ex App
-    participant LATER_Session as LATER Session Registry
-    participant LATER_Exec as LATER Executor
-    participant Gemini_API as Gemini API
-    
-    App->>LATER_Session: create_session("sid-123", [MyApp.WeatherTools])
-    App->>LATER_Session: list_declarations("sid-123")
-    LATER_Session-->>App: [%FunctionDeclaration{name: "get_current_weather", ...}]
-    
-    App->>Gemini_API: generate_content(prompt, tools=[...])
-    Gemini_API-->>App: response with FunctionCall{name: "get_current_weather", args: ...}
-    
-    App->>LATER_Exec: execute("sid-123", FunctionCall{...})
-    LATER_Exec-->>App: {:ok, FunctionResponse{...}}
-    
-    App->>Gemini_API: generate_content(history_with_response)
-    Gemini_API-->>App: "The weather in Boston is 22°C and windy."
+    participant Dev as Developer
+    participant App as Host Application (e.g., gemini_ex)
+    participant LATER as LATER Runtime
+    participant LLM as Large Language Model
+
+    Dev->>+App: Defines `CalculatorTools.add/2` with `deftool`
+    Note over App,LATER: At compile time, `deftool` introspects<br/>`add/2` and populates the<br/>Global Tool Registry.
+
+    App->>+LATER: Start Session("session-123", tools: [:add])
+    LATER->>LATER: Create Session-Scoped Registry for "session-123"
+
+    App->>+LLM: generate_content("What is 5 + 7?", tools: [FunctionDeclaration for :add])
+    LLM-->>-App: FunctionCall(name: "add", args: %{a: 5, b: 7})
+
+    App->>LATER: Executor.execute("session-123", FunctionCall)
+    LATER->>LATER: 1. Validate "add" is in session registry
+    LATER->>LATER: 2. Validate args `{a: 5, b: 7}` against schema
+    LATER->>LATER: 3. Invoke `CalculatorTools.add(5, 7)`
+    LATER-->>-App: ToolResult(name: "add", status: :SUCCESS, content: 12)
+
+    App->>+LLM: generate_content(..., tool_results: [ToolResult])
+    LLM-->>-App: Final Response("The sum of 5 and 7 is 12.")
+    deactivate LATER
 ```
 
-This workflow demonstrates the clean separation: `gemini_ex` coordinates the conversation with the LLM, while the LATER implementation handles the local tool mechanics of registration, discovery, and execution.
+**Code Snippets (Illustrative):**
+
+```elixir
+# 1. Host application starts a session and gets available tools
+{:ok, session} = Later.Session.start(tools: ["add/2", "calculate_total/3"])
+declarations = Later.Session.get_tool_declarations(session)
+
+# 2. Host sends declarations to the LLM
+response = Gemini.generate("What is 15 + 30?", tools: declarations)
+# response.function_call = %FunctionCall{name: "add", args: %{a: 15, b: 30}}
+
+# 3. Host dispatches the FunctionCall to the LATER Executor
+result = Later.Executor.execute(session, response.function_call)
+# result = %ToolResult{name: "add", status: :SUCCESS, content: 45}
+
+# 4. Host sends the result back to the LLM to get the final answer
+final_response = Gemini.generate(..., tool_results: [result])
+# final_response.text = "The result is 45."
+```
+
+## 5. Promotion Path to GRID
+
+A core architectural benefit of LATER is the seamless "promotion path" for a tool to a distributed **GRID (Global Runtime & Interface Definition)** environment. This migration requires **no changes to the tool's ADM contract** (`FunctionDeclaration`).
+
+The promotion is achieved at the host application layer by changing the tool's source.
+
+**Migration Steps:**
+
+1.  **Deploy the Tool:** The native function (e.g., `CalculatorTools.add/2`) is deployed within a GRID-compliant Runtime service, separate from the host application. This Runtime exposes the tool over the network.
+2.  **Change the Tool Source:** The host application is reconfigured to source the `add/2` tool from the GRID client instead of the local LATER runtime.
+
+This works because both LATER and GRID present the same ADM `FunctionDeclaration` to the LLM. The model is unaware of the execution backend; it simply sees a tool contract it can use.
+
+**Conceptual Example of a Host Application's `ToolSource`:**
+
+```elixir
+# --- Using a LATER tool ---
+config :my_app, tool_sources: [
+  LATER.ToolSource # Points to the local, in-process executor
+]
+
+# --- Using a GRID tool (after promotion) ---
+config :my_app, tool_sources: [
+  GRID.ToolSource, # Points to a remote GRID client
+  config: [host: "grid.example.com", port: 8080]
+]
+```
+
+By adhering to the ADM as the universal contract, LATER ensures that local tools are built from day one to be compatible with the broader, enterprise-grade ecosystem, fulfilling the "write once, run anywhere" promise of the ALTAR architecture.


### PR DESCRIPTION
This commit introduces the complete, final v1.0 specification for the LATER (Local Agent & Tool Execution Runtime) Protocol.

The document synthesizes the architectural vision, data model contracts, and formal requirements from three source documents into a single, comprehensive specification:
- `specs/01-data-model/README.md`
- `priv/docs/LATERinitialBrainstorms/docs/20250805_01.md`
- `priv/docs/LATERinitialBrainstorms/.kiro/specs/later-v1-foundational-spec/requirements.md`

The resulting specification in `specs/02-later-protocol/README.md` defines the abstract components, data contracts, and implementation patterns required for a LATER-compliant system, establishing it as the local-first, in-process companion to the distributed GRID protocol within the ALTAR ecosystem.