### PR TITLE
Refactor: Clarify terminology across ALTAR specifications

### DIFF
--- a/priv/docs/specs/01-data-model/data-model.md
+++ b/priv/docs/specs/01-data-model/data-model.md
@@ -1,4 +1,4 @@
-# ALTAR Data Model (ADM) Specification v1.0
+# ALTAR Data Model (ADM) v1.0: A Universal Contract for AI Tools
 
 **Version:** 1.0.0  
 **Status:** Final  
@@ -8,14 +8,7 @@
 
 ### 1.1. Purpose and Scope
 
-The ALTAR Data Model (ADM) v1.0 specification **adopts and standardizes** a set of data structures based on established industry patterns (notably Google Gemini's function calling API and OpenAPI 3.0) to serve as a universal, interoperable contract. Its primary purpose is to ensure that a tool defined for one execution environment (e.g., local development) can be **seamlessly promoted** to another (e.g., a secure, distributed production environment) without modification.
-
-By aligning with proven, real-world schemas, the ADM provides a reliable and language-agnostic foundation for:
-- Declaring tool capabilities and metadata
-- Defining function parameter schemas and validation rules
-- Structuring function call requests and responses
-- Handling errors and reporting status
-- Managing trusted tool manifests for Host-centric security models
+This document is a **Data Model Specification**. It defines a set of language-agnostic data structures and contracts (`FunctionDeclaration`, `FunctionCall`, etc.) that serve as the universal language for the ALTAR ecosystem. It does **not** define execution logic or communication protocols; it defines the payload they carry.
 
 ### 1.2. Three-Layer Architecture
 
@@ -25,14 +18,14 @@ The ALTAR ecosystem is built on a three-layer architecture, with the ADM serving
 graph TB
     %% --- Define Protocol Layers ---
     L3("
-        <strong>Layer 3: GRID Protocol</strong><br/><br/>
+        <strong>Layer 3: GRID Architecture</strong><br/><br/>
         Distributed Tool Orchestration<br/>
         Host-Runtime Communication & Enterprise<br/>
         Security & Observability
     ")
 
     L2("
-        <strong>Layer 2: LATER Protocol</strong><br/><br/>
+        <strong>Layer 2: LATER Pattern</strong><br/><br/>
         Local Tool Execution<br/>
         In-Process Function Calls<br/>
         Development & Prototyping
@@ -57,28 +50,13 @@ graph TB
 
 **Layer 1 - ALTAR Data Model (ADM):** Defines the universal data structures and contracts for AI tool interactions. This layer is purely structural and contains no execution or transport logic.
 
-**Layer 2 - LATER Protocol:** Implements local, in-process tool execution using ADM data structures. LATER provides the runtime environment for development and prototyping scenarios.
+**Layer 2 - LATER Pattern:** Implements local, in-process tool execution using ADM data structures. LATER provides the runtime environment for development and prototyping scenarios.
 
-**Layer 3 - GRID Protocol:** Implements distributed tool orchestration using ADM data structures. GRID provides enterprise-grade security, observability, and scalability for production deployments.
+**Layer 3 - GRID Architecture:** Implements distributed tool orchestration using ADM data structures. GRID provides enterprise-grade security, observability, and scalability for production deployments.
 
-### 1.3. Relationship to LATER and GRID Protocols
+### 1.3. Relationship to LATER and GRID
 
-The ADM serves as the foundational contract that both LATER and GRID protocols import and implement:
-
-**LATER Protocol Integration:**
-- LATER imports all ADM data structures for local tool execution
-- Tool definitions created using ADM structures work seamlessly in LATER environments
-- LATER provides the execution runtime while ADM provides the data contracts
-
-**GRID Protocol Integration:**
-- GRID imports all ADM data structures for distributed tool orchestration
-- Tools defined using ADM structures can be promoted from LATER to GRID without modification
-- GRID adds transport, security, and observability layers while preserving ADM contracts
-
-**Interoperability Benefits:**
-- Tools defined once using ADM structures work in both LATER and GRID environments
-- Migration between local and distributed execution requires no structural changes
-- Consistent data formats enable seamless ecosystem integration
+The ADM is the foundational layer that is **imported and used by** both the LATER implementation pattern and the GRID reference architecture. LATER provides a standard way to execute these contracts in-process, while GRID provides a blueprint for executing them in a distributed environment.
 
 ## 2. Serialization Format
 
@@ -163,7 +141,7 @@ The ADM is not a new invention, but a pragmatic **adoption and standardization**
 
 **1. Industry Compatibility (Primary Rationale):** The ADM's core value is its alignment with the existing AI and API ecosystem. By adopting patterns from Google's Gemini API and the OpenAPI 3.0 specification, the ADM ensures that ALTAR tools are immediately familiar and compatible with the technologies developers already use. This choice reduces the learning curve and enables seamless integration with a wide range of LLM clients, API gateways, and validation tools.
 
-**2. Structural Purity for Portability:** The specification strictly defines data structures, deliberately excluding execution logic, networking, or host-specific concerns. This separation is critical for the "promotion path" value proposition, as it guarantees that a tool's contract remains pure and portable between the `LATER` (local) and `GRID` (distributed) protocols.
+**2. Structural Purity for Portability:** The specification strictly defines data structures, deliberately excluding execution logic, networking, or host-specific concerns. This separation is critical for the "promotion path" value proposition, as it guarantees that a tool's contract remains pure and portable between the `LATER` (local) implementation pattern and `GRID` (distributed) architecture.
 
 **3. Language Neutrality via JSON:** By mandating JSON as the canonical serialization format, the ADM ensures that tools and hosts can be implemented in any programming language without compromising compatibility.
 
@@ -4046,7 +4024,7 @@ The ToolManifest structure serves as the cornerstone of ALTAR's Host-centric sec
 }
 ```
 
-## 5. Protocol Versioning and Evolution
+## 5. Versioning and Evolution
 
 ### 5.1. Versioning Strategy
 
@@ -4126,7 +4104,7 @@ The ADM uses semantic versioning (SemVer) with the format `MAJOR.MINOR.PATCH`:
 - Cross-version compatibility should be handled gracefully
 
 **Version Negotiation:**
-- Higher-layer protocols (LATER, GRID) may implement version negotiation
+- Higher-layer specifications (LATER, GRID) may implement version negotiation
 - Implementations should support the highest mutually compatible version
 - Fallback to lower versions should maintain functional compatibility
 
@@ -4222,8 +4200,8 @@ The following field names are reserved for future use across all data structures
 
 **Namespace Conventions:**
 - **Core ADM:** No prefix (current specification)
-- **LATER Protocol:** `later_*` prefix for LATER-specific extensions
-- **GRID Protocol:** `grid_*` prefix for GRID-specific extensions
+- **LATER Pattern:** `later_*` prefix for LATER-specific extensions
+- **GRID Architecture:** `grid_*` prefix for GRID-specific extensions
 - **Vendor Extensions:** `vendor_name_*` prefix for vendor-specific additions
 - **Experimental:** `x_*` prefix for experimental features
 
@@ -4305,15 +4283,22 @@ Implementations may add custom extensions following these guidelines:
 - Version compatibility should include extension compatibility
 - Fallback behavior should be defined for unsupported extensions
 
-**Cross-Protocol Compatibility:**
-- Extensions should consider LATER and GRID protocol needs
-- Protocol-specific extensions should not conflict with core ADM
-- Extension namespacing should prevent cross-protocol conflicts
+**Cross-Specification Compatibility:**
+- Extensions should consider LATER and GRID specification needs
+- Specification-specific extensions should not conflict with core ADM
+- Extension namespacing should prevent cross-specification conflicts
 - Shared extensions should be promoted to core ADM when appropriate
+
+### 5.3. Future Technical Refinement: Adopting JSON Schema
+
+> The v1.0 `parameters` object is a simple map representing an OpenAPI-like schema. While functional for an MVP, a key goal for a future revision (v1.1) is to replace this custom map with a standard **JSON Schema object**. Adopting the official JSON Schema standard will provide significant benefits:
+> - **Rich Validation:** Access to a full vocabulary of validation keywords (`pattern`, `minLength`, `maximum`, etc.), making tool definitions far more robust.
+> - **Industry Alignment:** Conformance with the exact standard used by major AI providers like Google and OpenAI.
+> - **Ecosystem Tooling:** The ability to leverage the vast ecosystem of JSON Schema validators, UI generators, and other tools in any language.
 
 ## 6. Conclusion
 
-The ALTAR Data Model (ADM) v1.0 specification provides a robust, language-agnostic foundation for defining and interacting with AI tools. By establishing a universal contract for data structures, the ADM ensures seamless interoperability across the ALTAR ecosystem, from local development with the LATER protocol to distributed production environments with the GRID protocol.
+The ALTAR Data Model (ADM) v1.0 specification provides a robust, language-agnostic foundation for defining and interacting with AI tools. By establishing a universal contract for data structures, the ADM ensures seamless interoperability across the ALTAR ecosystem, from local development with the LATER implementation pattern to distributed production environments with the GRID architecture.
 
 This document serves as the authoritative v1.0 reference for all ADM implementations. Adherence to this specification is essential for ensuring that tools are portable, compatible, and can evolve gracefully within the broader ALTAR architecture.
 

--- a/priv/docs/specs/02-later-protocol/later-protocol.md
+++ b/priv/docs/specs/02-later-protocol/later-protocol.md
@@ -1,4 +1,4 @@
-# LATER (Local Agent & Tool Execution Runtime) Protocol v1.0
+# LATER (Local Agent & Tool Execution Runtime) v1.0: A Standard Implementation Pattern
 
 **Version:** 1.0.0
 **Status:** Final
@@ -8,30 +8,30 @@
 
 ### 1.1. Vision & Guiding Principles
 
-The **LATER (Local Agent & Tool Execution Runtime) Protocol** provides a language-agnostic standard for local, in-process AI tool execution. It is designed to be the **frictionless on-ramp to production** for the ALTAR ecosystem. Its primary purpose is to enable developers to build and test tools locally that are *guaranteed* to be compatible with the secure, scalable **GRID** execution environment, ensuring a seamless transition from development to deployment.
+The **LATER (Local Agent & Tool Execution Runtime) Pattern** provides a language-agnostic standard for building libraries that handle local, in-process AI tool execution. It is designed to be the **frictionless on-ramp to production** for the ALTAR ecosystem. Its primary purpose is to enable developers to build and test tools locally that are *guaranteed* to be compatible with the secure, scalable **GRID** execution environment, ensuring a seamless transition from development to deployment.
 
 LATER is governed by three core principles:
 
 1.  **The Frictionless On-Ramp to Production:** Every feature in LATER is designed with the "promotion path" in mind. The developer experience is optimized to ensure that code written for local execution works identically when pointed at the distributed GRID backend, eliminating the need for costly and error-prone rewrites.
 2.  **Implements the ADM:** LATER is a consumer of the **ALTAR Data Model (ADM)**. All data structures it produces and consumes (`FunctionDeclaration`, `FunctionCall`, `ToolResult`, etc.) must conform to the ADM v1.0 specification. This shared contract is what makes the promotion path possible.
-3.  **Developer Experience & Introspection:** The protocol prioritizes a world-class developer experience. A compliant implementation must favor automated schema generation from native function signatures and documentation, minimizing boilerplate and manual configuration. It must also provide adapters for popular existing AI frameworks (see Section 2.4).
+3.  **Developer Experience & Introspection:** The implementation standard prioritizes a world-class developer experience. A compliant implementation must favor automated schema generation from native function signatures and documentation, minimizing boilerplate and manual configuration. It must also provide adapters for popular existing AI frameworks (see Section 2.4).
 
 ### 1.2. Relationship to ADM & GRID
 
-LATER is the second layer in the three-layer ALTAR architecture, positioned between the foundational data model and the distributed execution protocol.
+LATER is not a communication protocol but a **standard pattern for implementing a local runtime**. It consumes the ADM specification to define tool contracts and serves as the local development counterpart to the GRID distributed architecture blueprint.
 
 ```mermaid
 graph TB
     subgraph AE["ALTAR Ecosystem"]
         L3("
-            <strong>Layer 3: GRID Protocol</strong><br/><br/>
+            <strong>Layer 3: GRID Architecture</strong><br/><br/>
             Distributed Tool Orchestration<br/>
             Inter-Process & Network Communication<br/>
             Manages Security & Transport
         ")
 
         L2("
-            <strong>Layer 2: LATER Protocol (This Specification)</strong><br/><br/>
+            <strong>Layer 2: LATER Pattern (This Specification)</strong><br/><br/>
             Local Tool Execution Runtime<br/>
             In-Process Function Calls<br/>
             Automated Introspection
@@ -56,10 +56,7 @@ graph TB
     style L1 fill:#0d47a1,stroke:#002171,color:#ffffff
 ```
 
-*   **LATER implements the ADM:** It provides a standard for *creating* and *executing* tools that are described by ADM data structures.
-*   **LATER is the local companion to GRID:** Where GRID defines how tools operate across a network, LATER defines how they operate within a single process. This clear separation of concerns allows for a "promotion path" where a tool can graduate from a local LATER runtime to a distributed GRID runtime with no changes to its fundamental contract.
-
-## 2. Abstract Protocol Definition
+## 2. Abstract Implementation Definition
 
 A LATER-compliant implementation must provide the following conceptual components and behaviors. These definitions are language-agnostic; the subsequent section provides a canonical implementation pattern in Elixir.
 
@@ -344,7 +341,7 @@ This commitment to interoperability is central to LATER's mission. It ensures de
 
 ## 3. Canonical Implementation Pattern: Elixir
 
-This section provides a brief, non-normative example of how the abstract protocol can be idiomatically implemented in Elixir. This serves as a reference for implementers in other languages.
+This section provides a brief, non-normative example of how the abstract implementation standard can be idiomatically implemented in Elixir. This serves as a reference for implementers in other languages.
 
 #### 3.1. Tool Declaration with `deftool`
 
@@ -408,7 +405,7 @@ This section illustrates the complete end-to-end workflow, demonstrating the cor
 
 ### 4.1. The End-to-End LATER Flow
 
-The following diagram shows the sequence of events when a tool is executed locally using the LATER protocol.
+The following diagram shows the sequence of events when a tool is executed locally using the LATER pattern.
 
 ```mermaid
 sequenceDiagram

--- a/priv/docs/specs/03-grid-protocol/aesp.md
+++ b/priv/docs/specs/03-grid-protocol/aesp.md
@@ -1,4 +1,4 @@
-# AESP (ALTAR Enterprise Security Protocol) Profile v1.0
+# AESP (ALTAR Enterprise Security Profile) v1.0: Enterprise Controls for the GRID Architecture
 
 **Version:** 1.0
 **Status:** Final
@@ -9,16 +9,16 @@
 
 ### 1.1. Overview
 
-This document defines the **AESP (ALTAR Enterprise Security Protocol) Profile v1.0**. AESP is not a standalone protocol; it is a formal profile of the [GRID Protocol](./README.md) that specifies the mandatory architectural components, message extensions, and security controls required to achieve **Level 3 Enterprise Compliance**.
+This document defines the **AESP (ALTAR Enterprise Security Profile) v1.0**. AESP is a formal profile for the [GRID Architecture](./README.md) that specifies the mandatory architectural components, API contract extensions, and security controls required to achieve enterprise-grade compliance.
 
-The primary purpose of AESP is to elevate the core GRID protocol to meet the stringent demands of enterprise environments. Where GRID provides a robust foundation for distributed tool orchestration, AESP layers on the critical features of **security, governance, and compliance**. An AESP-compliant system is, by definition, a GRID-compliant system that has been hardened and extended for high-stakes, regulated deployments.
+The primary purpose of AESP is to elevate the core GRID architecture to meet the stringent demands of enterprise environments. Where GRID provides a robust foundation for distributed tool orchestration, AESP layers on the critical features of **security, governance, and compliance**. An AESP-compliant system is, by definition, a GRID-compliant system that has been hardened and extended for high-stakes, regulated deployments.
 
 ### 1.2. Relationship to GRID
 
-AESP extends the GRID protocol through three primary mechanisms, ensuring that an AESP-compliant Host remains interoperable with the core principles of GRID while enforcing stricter enterprise-grade controls.
+AESP extends the GRID architecture through three primary mechanisms, ensuring that an AESP-compliant Host remains interoperable with the core principles of GRID while enforcing stricter enterprise-grade controls.
 
 *   **Component Mandates:** AESP mandates the implementation of a specific **Control Plane** architecture. A standard GRID Host is extended with required services for identity, policy, audit, and more, which become integral to its operation.
-*   **Message Replacement:** AESP selectively replaces certain base GRID protocol messages with enterprise-specific counterparts. These extended messages (e.g., `EnterpriseSecurityContext`) are supersets of the base messages, carrying additional data required for fine-grained policy enforcement, auditability, and governance.
+*   **Message Replacement:** AESP selectively replaces certain base GRID API contracts with enterprise-specific counterparts. These extended messages (e.g., `EnterpriseSecurityContext`) are supersets of the base messages, carrying additional data required for fine-grained policy enforcement, auditability, and governance.
 *   **Stricter Security:** AESP elevates GRID's security posture from a recommendation to a requirement. It mandates specific security controls, such as mTLS 1.3+ for all transport, integration with enterprise identity providers (IdPs), and the maintenance of an immutable audit log.
 
 ### 1.3. Incremental Adoption: AESP Compliance Tiers
@@ -129,7 +129,7 @@ This mapping demonstrates that AESP is not a proprietary, black-box system but r
 
 ## 3. AESP Message Replacements and Extensions
 
-AESP achieves its enhanced capabilities by replacing key GRID protocol messages with extended enterprise versions. These messages are designed to be supersets of their base counterparts.
+AESP achieves its enhanced capabilities by replacing key GRID API contracts with extended enterprise versions. These messages are designed to be supersets of their base counterparts.
 
 ### 3.1. `EnterpriseSecurityContext`
 
@@ -250,8 +250,8 @@ AESP mandates a set of non-negotiable security controls to ensure a hardened, en
 AESP provides the final, most secure stage in the ALTAR tool lifecycle. The promotion path to a fully governed enterprise tool is as follows:
 
 1.  A tool is first defined using the standard **ALTAR Data Model (ADM)**.
-2.  It is tested and run locally using the **LATER** protocol.
-3.  It is deployed to a standard **GRID** environment for distributed execution.
+2.  It is tested and run locally using the **LATER** implementation pattern.
+3.  It is deployed to a standard **GRID** architecture for distributed execution.
 4.  Finally, for enterprise use, its definition is promoted to an **`EnterpriseToolContract`**. This enrichment process involves adding security classifications, risk assessments, and compliance tags. The contract is then submitted to the **`EnterpriseGovernanceService`** for formal review and approval.
 
 Once approved and active in the AESP Host's manifest, the tool is fully subject to the control plane's policies. Every call is authenticated, authorized by the RBAC and Policy Engines, and meticulously recorded by the Audit Manager, completing its journey to a fully governed enterprise asset.

--- a/priv/docs/specs/03-grid-protocol/grid-protocol.md
+++ b/priv/docs/specs/03-grid-protocol/grid-protocol.md
@@ -1,4 +1,4 @@
-# GRID Protocol Specification v1.0
+# GRID (Global Runtime & Interop Director) v1.0: A Reference Architecture for Distributed Tool Execution
 
 **Version:** 1.0.0
 **Status:** Final
@@ -8,7 +8,7 @@
 
 ### 1.1. Vision & Guiding Principles
 
-The **GRID (Global Runtime & Interop Director) Protocol** is the secure, scalable execution backend for the ALTAR ecosystem. It provides the **production-grade fulfillment layer** for tools developed and tested with the LATER protocol, solving the critical security, governance, and operational challenges that are not addressed by open-source development frameworks.
+The **GRID (Global Runtime & Interop Director) Architecture** is a blueprint for a secure, scalable, and distributed backend for the ALTAR ecosystem. It describes the necessary components (Host, Runtime), their interactions, and the security model required for production-grade tool fulfillment.
 
 GRID is built on two core principles:
 
@@ -17,16 +17,16 @@ GRID is built on two core principles:
 
 ### 1.2. Relationship to ADM & LATER
 
-GRID is the third layer of the three-layer ALTAR architecture, building upon the foundational contracts established by the ALTAR Data Model (ADM) and complementing the local execution model of the LATER protocol.
+GRID is the third layer of the three-layer ALTAR architecture, building upon the foundational contracts established by the ALTAR Data Model (ADM) and complementing the local execution model of the LATER implementation pattern.
 
 ```mermaid
 graph TB
-    subgraph L3["Layer&nbsp;3:&nbsp;GRID&nbsp;Protocol&nbsp;(This&nbsp;Specification)"]
+    subgraph L3["Layer&nbsp;3:&nbsp;GRID&nbsp;Architecture&nbsp;(This&nbsp;Blueprint)"]
         direction TB
         A["<strong>Distributed Tool Orchestration</strong><br/>Host-Runtime Communication<br/>Enterprise Security & Observability"]
     end
 
-    subgraph L2["Layer&nbsp;2:&nbsp;LATER&nbsp;Protocol"]
+    subgraph L2["Layer&nbsp;2:&nbsp;LATER&nbsp;Pattern"]
         direction TB
         B["<strong>Local Tool Execution</strong><br/>In-Process Function Calls<br/>Development & Prototyping"]
     end
@@ -44,12 +44,12 @@ graph TB
     style L1 fill:#0d47a1,stroke:#002171,color:#ffffff
 ```
 
--   **Imports the ADM:** GRID is a consumer of the **ALTAR Data Model (ADM)**. All data payloads within GRID messages, such as function calls and results, **must** conform to the structures defined in the ADM specification (`FunctionCall`, `ToolResult`, etc.). GRID defines the messages that *transport* these ADM structures between processes.
--   **Distributed Counterpart to LATER:** Where the LATER protocol specifies in-process tool execution for development, GRID specifies out-of-process, distributed tool execution for scalable, production-ready systems.
+-   **Imports the ADM:** GRID is a consumer of the **ALTAR Data Model (ADM)**. All data payloads within GRID messages, such as function calls and results, **must** conform to the structures defined in the ADM specification (`FunctionCall`, `ToolResult`, etc.). This architecture defines the messages that *transport* these ADM structures between processes.
+-   **Distributed Counterpart to LATER:** Where the LATER pattern specifies in-process tool execution for development, this blueprint specifies out-of-process, distributed tool execution for scalable, production-ready systems.
 
 ## 2. Architecture: The Host-Runtime Model
 
-The GRID protocol is based on a Host-Runtime architecture, where a central Host orchestrates communication between clients and one or more Runtimes.
+The GRID architecture is based on a Host-Runtime model, where a central Host orchestrates communication between clients and one or more Runtimes.
 
 ```mermaid
 graph LR
@@ -284,15 +284,17 @@ This dual-mode approach enables organizations to maintain strict security contro
 
 > **Note on the `ToolContract` Definition**
 >
-> To maintain a clean separation of concerns, the definition of a `ToolContract` is layered across the ALTAR protocol suite:
+> To maintain a clean separation of concerns, the definition of a `ToolContract` is layered across the ALTAR specification suite:
 >
 > 1.  **Structural Core (ADM):** The foundational **ALTAR Data Model (ADM)** defines the `FunctionDeclaration`, which is the universal, language-agnostic structural core of any tool's contract.
-> 2.  **Conceptual Formalization (GRID):** The **GRID Protocol** (this document) formalizes the *concept* of a `ToolContract` as the trusted, Host-managed agreement that contains one or more `FunctionDeclaration`s. This is the level at which security and fulfillment policies are applied.
+> 2.  **Conceptual Formalization (GRID):** The **GRID Architecture** (this document) formalizes the *concept* of a `ToolContract` as the trusted, Host-managed agreement that contains one or more `FunctionDeclaration`s. This is the level at which security and fulfillment policies are applied.
 > 3.  **Enterprise Enrichment (AESP):** The **AESP (ALTAR Enterprise Security Profile)** further enriches this concept into a specific `EnterpriseToolContract` message, adding detailed fields for governance, compliance, and risk management.
 >
 > This layered approach allows the core tool definition to remain simple and universal while being progressively enhanced with the security and governance features required for more advanced, production-grade deployments.
 
-## 4. Protocol Message Schemas (Language-Neutral IDL)
+## 4. Conceptual API Contracts and Message Schemas
+
+> **Disclaimer:** The schemas defined below represent the **conceptual contracts** between the components in the GRID architecture. They are presented in a language-neutral IDL format. A concrete implementation of this architecture would realize these contracts using a specific wire protocol like gRPC (defining services in a `.proto` file) or a REST/HTTP API. The choice of wire protocol is an implementation detail of the GRID architecture.
 
 These schemas define the messages exchanged between the Host and Runtimes. All payloads referencing tool structures (e.g., `FunctionCall`, `ToolResult`) are defined by the **ALTAR Data Model (ADM) Specification**.
 


### PR DESCRIPTION
This commit performs a minimal-modification pass on the four core ALTAR specification documents (ADM, LATER, GRID, AESP) to refactor the terminology and clarify the distinct purpose of each document.

The term "protocol" was previously used incorrectly, leading to confusion between data models, implementation patterns, and system architectures. This refactoring addresses the issue by applying the following conceptual clarifications:

1.  **ADM (Altar Data Model):** Reframed as a **Data Model Specification**. It defines the data structures (the "nouns") used across the ecosystem, not a communication protocol.

2.  **LATER (Local Agent & Tool Execution Runtime):** Reframed as a **Library Implementation Pattern**. It describes a standard for building local, in-process runtimes, not a protocol for inter-process communication.

3.  **GRID (Global Runtime & Interop Director):** Reframed as a **System Architecture Blueprint**. It describes the components and responsibilities of a distributed system, not a concrete wire protocol.

4.  **AESP (ALTAR Enterprise Security Profile):** Reframed as a **Security and Governance Profile** for the GRID architecture, clarifying its role as an extension for enterprise controls.

These changes align the documentation with standard industry terminology, providing a clearer and more maintainable foundation for the project's evolution.